### PR TITLE
Improvements for running on windows

### DIFF
--- a/makefile
+++ b/makefile
@@ -7,9 +7,24 @@ prefix := /usr/local
 EXTRA_FBFLAGS := -maxerr 1
 FBFROG_FBFLAGS := -m fbfrog $(FBFLAGS) $(EXTRA_FBFLAGS)
 TESTRUNNER_FBFLAGS := $(FBFLAGS) $(EXTRA_FBFLAGS)
+TESTRUNNER_ARGS :=
 
 ifdef ENABLE_STANDALONE
   FBFROG_FBFLAGS += -d ENABLE_STANDALONE
+endif
+
+ifdef ENABLE_COMMON_PATHDIV
+  # When ENABLE_COMMON_PATHDIV defined: 
+  # - Use forward slash '/' for path division on all targets
+  # - This helps with compatibility for  shell scripts.
+  # When ENABLE_COMMON_PATHDIV not defined:
+  # - use backslash '\' for path division on windows and dos
+  # - use forward slash '/' for all other targets
+  #
+  # See src/util-path.bi: HOST_PATHDIV and PATHDIV
+
+  FBFROG_FBFLAGS += -d ENABLE_COMMON_PATHDIV
+  TESTRUNNER_FBFLAGS += -d ENABLE_COMMON_PATHDIV 
 endif
 
 SOURCES := $(sort $(wildcard src/*.bas))
@@ -44,7 +59,7 @@ unittests/run$(EXEEXT): unittests/run.bas src/obj/libfbfrog.a $(UNITTESTS_HEADER
 	$(QUIET_FBCLINK)$(FBC) $< src/obj/libfbfrog.a $(TESTRUNNER_FBFLAGS) -x $@
 
 tests: build unittests
-	tests/run$(EXEEXT)
+	tests/run$(EXEEXT) $(TESTRUNNER_ARGS)
 
 unittests: build
 	unittests/run$(EXEEXT)

--- a/makefile
+++ b/makefile
@@ -8,6 +8,10 @@ EXTRA_FBFLAGS := -maxerr 1
 FBFROG_FBFLAGS := -m fbfrog $(FBFLAGS) $(EXTRA_FBFLAGS)
 TESTRUNNER_FBFLAGS := $(FBFLAGS) $(EXTRA_FBFLAGS)
 
+ifdef ENABLE_STANDALONE
+  FBFROG_FBFLAGS += -d ENABLE_STANDALONE
+endif
+
 SOURCES := $(sort $(wildcard src/*.bas))
 HEADERS := $(wildcard src/*.bi)
 OBJECTS := $(patsubst src/%.bas,src/obj/%.o,$(SOURCES))
@@ -49,8 +53,14 @@ clean:
 	rm -f fbfrog$(EXEEXT) tests/run$(EXEEXT) unittests/run$(EXEEXT) src/obj/*.a src/obj/*.o
 
 install:
+ifdef ENABLE_STANDALONE
+	install fbfrog$(EXEEXT) "$(prefix)"
+	mkdir -p "$(prefix)/fbfrog/include"
+	cp -R include/fbfrog/* "$(prefix)/fbfrog/include"
+else
 	install fbfrog$(EXEEXT) "$(prefix)/bin"
 	cp -R include/fbfrog "$(prefix)/include"
+endif
 
 COMMIT = $(shell git rev-parse --verify HEAD)
 tarball:

--- a/src/c-pp.bas
+++ b/src/c-pp.bas
@@ -1695,7 +1695,7 @@ sub CppContext.parseInclude(byval begin as integer, byref flags as integer, byva
 	'' Get the normalized representation of the path, for use in hash tables
 	'' etc. Otherwise foo.h from the root dir and ../foo.h from a subdir
 	'' would be seen as different files.
-	incfile = pathNormalize(pathMakeAbsolute(incfile))
+	incfile = pathNormalizePathDiv(pathNormalize(pathMakeAbsolute(incfile)))
 
 	'' * Don't preserve internal #includes,
 	'' * don't preserve #includes if we will emit the #included content

--- a/src/c-pp.bas
+++ b/src/c-pp.bas
@@ -1921,6 +1921,7 @@ sub CppContext.parseDefine(byref flags as integer)
 		if prevdef->equals(*tk, definfo) = FALSE then
 			'' TODO: should only report once per symbol (per fbfrog run, not cpp run)
 			print "conflicting #define " + *macro->text
+			return
 		end if
 	end if
 

--- a/src/c-pp.bas
+++ b/src/c-pp.bas
@@ -1921,7 +1921,6 @@ sub CppContext.parseDefine(byref flags as integer)
 		if prevdef->equals(*tk, definfo) = FALSE then
 			'' TODO: should only report once per symbol (per fbfrog run, not cpp run)
 			print "conflicting #define " + *macro->text
-			return
 		end if
 	end if
 

--- a/src/fbfrog.bas
+++ b/src/fbfrog.bas
@@ -306,6 +306,8 @@ private sub hLoadArgsFile _
 
 	filename = hFindResource(filename)
 
+	filename = pathNormalizePathDiv(filename)
+
 	'' Load the file content at the specified position
 	lexLoadArgs(frog.sourcectx, tk, x, frog.sourcectx.addFileSource(filename, location))
 	filecount += 1
@@ -1124,6 +1126,7 @@ private function frogParse(byref api as ApiInfo) as AstNode ptr
 					assert(i->kind = ASTKIND_OPTION)
 					if i->opt = OPT_FBFROGINCLUDE then
 						var filename = hFindResource(*i->text)
+						filename = pathNormalizePathDiv(filename)
 						var x = tk.count()
 						lexLoadC(frog.sourcectx, tk, x, frog.sourcectx.addFileSource(filename, i->location))
 						tk.setRemove(x, tk.count() - 1)

--- a/src/fbfrog.bas
+++ b/src/fbfrog.bas
@@ -254,6 +254,13 @@ private function hTurnArgsIntoString(byval argc as integer, byval argv as zstrin
 		'' If the argument contains special chars (white-space, ", '),
 		'' enclose it in quotes as needed for lexLoadArgs().
 
+		#if defined(__FB_WIN32__) or defined(__FB_DOS__)
+			'' WIN32_HACKS
+			'' assume that if ^* was passed in, it was to escape the
+			'' asterick and prevent wildcard expansion
+			arg = strReplace(arg, $"^*", $"*")
+		#endif
+
 		'' Contains '?
 		if instr(arg, "'") > 0 then
 			'' Must enclose in "..." and escape included " or \ chars properly.

--- a/src/fbfrog.bas
+++ b/src/fbfrog.bas
@@ -266,6 +266,22 @@ private function hTurnArgsIntoString(byval argc as integer, byval argv as zstrin
 			'' Must enclose in "..." and escape included " or \ chars properly.
 			'' This also works if " or whitespace are included too.
 
+			#if defined(__FB_WIN32__) or defined(__FB_DOS__)
+				'' WIN32_HACKS
+				'' if there is exactly 2 single quotes at the start and end
+				'' then we probably want to just strip those off since the
+				'' shell didn't do it and we probably are passing something
+				'' like '*' or '*/filename' to prevent wildcard expansion
+
+				if arg = "''" then
+					arg = """"""
+				elseif len( arg ) > 2 then
+					if left( arg, 1 ) = "'" and right( arg, 1 ) = "'" then
+						arg = mid( arg, 2, len( arg ) - 2 )
+					end if
+				end if
+			#endif
+
 			'' Insert \\ for \ before inserting \" for ", so \" won't accidentally
 			'' be turned into \\".
 			arg = strReplace(arg, $"\", $"\\")

--- a/src/fbfrog.bas
+++ b/src/fbfrog.bas
@@ -206,8 +206,15 @@ private function hFindResource(byref filename as string) as string
 	var found = dir1 + filename
 	if fileexists(found) then return found
 
-	'' 4. <exepath>/../include/fbfrog/?
-	var dir2 = hExepath() + ".." + PATHDIV + INCLUDEDIR
+	#ifdef ENABLE_STANDALONE
+		'' 4. <exepath>/fbfrog/include/?
+		const ALTINCLUDEDIR = "fbfrog" + PATHDIV + "include" + PATHDIV
+		var dir2 = hExepath() + ALTINCLUDEDIR
+	#else
+		'' 4. <exepath>/../include/fbfrog/?
+		var dir2 = hExepath() + ".." + PATHDIV + INCLUDEDIR
+	#endif
+
 	found = dir2 + filename
 	if fileexists(found) then return found
 
@@ -215,7 +222,11 @@ private function hFindResource(byref filename as string) as string
 	print "search dirs:"
 	print "  <curdir> (" + curdir() + ")"
 	print "  <exepath>/include/fbfrog (" + dir1 + ")"
-	print "  <exepath>/../include/fbfrog (" + pathNormalize(dir2) + ")"
+	#ifdef ENABLE_STANDALONE
+		print "  <exepath>/fbfrog/include (" + dir2 + ")"
+	#else
+		print "  <exepath>/../include/fbfrog (" + pathNormalize(dir2) + ")"
+	#endif
 	end 1
 end function
 

--- a/src/highlevel.bas
+++ b/src/highlevel.bas
@@ -2489,7 +2489,8 @@ dim shared fbcrtheaders(0 to ...) as zstring ptr = _
 	@"assert", @"ctype", @"errno", @"float", @"limits", @"locale", _
 	@"math", @"setjmp", @"signal", @"stdarg", @"stddef", @"stdint", _
 	@"stdio", @"stdlib", @"string", @"time", _
-	@"sys/types", @"sys/socket", @"wchar" _
+	@"sys/types", @"sys/socket", @"wchar", _
+	@"sys/time", @"pthread", @"unistd" _
 }
 
 type IncludePass

--- a/src/util-path.bas
+++ b/src/util-path.bas
@@ -60,11 +60,11 @@ function pathAddDiv(byref path as const string) as string
 		case asc($"\"), asc("/")
 
 		case else
-			s += $"\"
+			s += PATHDIV
 		end select
 #else
 		if s[length-1] <> asc("/") then
-			s += "/"
+			s += PATHDIV
 		end if
 #endif
 	end if

--- a/src/util-path.bas
+++ b/src/util-path.bas
@@ -1,6 +1,7 @@
 '' Path/file name handling functions
 
 #include once "util-path.bi"
+#include once "util-str.bi"
 #include once "dir.bi"
 
 '' Searches backwards for the last '.' while still behind '/' or '\'.
@@ -127,6 +128,11 @@ end function
 
 function pathStripCurdir(byref path as const string) as string
 	var pwd = hCurdir()
+
+	#ifdef ENABLE_COMMON_PATHDIV
+	pwd = pathNormalizePathDiv(pwd)
+	#endif
+
 	if left(path, len(pwd)) = pwd then
 		function = right(path, len(path) - len(pwd))
 	else
@@ -267,4 +273,12 @@ function pathNormalize(byref path as const string) as string
 	next
 
 	function = left(s, w)
+end function
+
+function pathNormalizePathDiv(byref path as const string) as string
+	#if defined(ENABLE_COMMON_PATHDIV) andalso (PATHDIV <> HOST_PATHDIV)
+		return strReplace( path, HOST_PATHDIV, PATHDIV )
+	#else
+		return path
+	#endif
 end function

--- a/src/util-path.bas
+++ b/src/util-path.bas
@@ -159,7 +159,13 @@ function hReadableDirExists(byref path as const string) as integer
 	if right(fixed, len(PATHDIV)) = PATHDIV then
 		fixed = left(fixed, len(fixed) - len(PATHDIV))
 	end if
-	function = (len(dir(fixed, fbDirectory or fbReadOnly or fbHidden)) > 0)
+	#if defined(__FB_WIN32__) or defined(__FB_DOS__)
+		dim attrib as integer = 0
+		var d = dir( fixed, fbDirectory or fbReadOnly or fbHidden or fbArchive, attrib )
+		function = (len(d) > 0) and ((attrib and fbDirectory) <> 0)
+	#else
+		function = (len(dir(fixed, fbDirectory or fbReadOnly or fbHidden)) > 0)
+	#endif
 end function
 
 function pathIsDir(byref s as const string) as integer

--- a/src/util-path.bi
+++ b/src/util-path.bi
@@ -1,7 +1,15 @@
 #if defined(__FB_WIN32__) or defined(__FB_DOS__)
-	const PATHDIV = $"\"
+	const HOST_PATHDIV = $"\"
+	#ifdef ENABLE_COMMON_PATHDIV
+		'' use forward slash internally, even on windows
+		'' this helps with compatibility in shell scripts
+		const PATHDIV = "/"
+	#else
+		const PATHDIV = HOST_PATHDIV
+	#endif
 #else
-	const PATHDIV = "/"
+	const HOST_PATHDIV = "/"
+	const PATHDIV = HOST_PATHDIV
 #endif
 
 declare function pathStripExt(byref path as const string) as string
@@ -17,3 +25,4 @@ declare function pathStripCurdir(byref path as const string) as string
 declare function hReadableDirExists(byref path as const string) as integer
 declare function pathIsDir(byref s as const string) as integer
 declare function pathNormalize(byref path as const string) as string
+declare function pathNormalizePathDiv(byref path as const string) as string

--- a/src/util-str.bas
+++ b/src/util-str.bas
@@ -42,12 +42,12 @@ end sub
 
 function strReplace _
 	( _
-		byref text as string, _
+		byref text as const string, _
 		byref a as string, _
 		byref b as string _
 	) as string
 
-	var result = text
+	dim result as string = text
 
 	var alen = len(a)
 	var blen = len(b)
@@ -183,6 +183,18 @@ function strMatch(byref s as const string, byref pattern as const string) as int
 	case "?", left(s, 1)
 		'' Current char matches; now check the rest.
 		return strMatch(right(s, len(s) - 1), right(pattern, len(pattern) - 1))
+
+#if defined(__FB_WIN32__) or defined(__FB_DOS__)
+	case "\"
+		return left(s,1) = "/" andalso _
+		       strMatch(right(s, len(s) - 1), right(pattern, len(pattern) - 1))
+
+	case "/"
+		return left(s,1) = "\" andalso _
+		       strMatch(right(s, len(s) - 1), right(pattern, len(pattern) - 1))
+
+#endif
+
 	end select
 
 	function = FALSE

--- a/src/util-str.bi
+++ b/src/util-str.bi
@@ -7,7 +7,7 @@ declare function strDuplicate(byval s as const zstring ptr) as zstring ptr
 declare sub strSplit(byref s as string, byref delimiter as string, byref l as string, byref r as string)
 declare function strReplace _
 	( _
-		byref text as string, _
+		byref text as const string, _
 		byref a as string, _
 		byref b as string _
 	) as string

--- a/tests/run.bas
+++ b/tests/run.bas
@@ -38,7 +38,7 @@ dim shared runner as TestRunner
 
 ''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-function strStripPrefix(byref s as string, byref prefix as string) as string
+function strStripPrefix(byref s as const string, byref prefix as const string) as string
 	if left(s, len(prefix)) = prefix then
 		function = right(s, len(s) - len(prefix))
 	else
@@ -46,11 +46,11 @@ function strStripPrefix(byref s as string, byref prefix as string) as string
 	end if
 end function
 
-function pathStripLastComponent(byref path as string) as string
+function pathStripLastComponent(byref path as const string) as string
 	function = pathOnly(left(path, len(path) - 1))
 end function
 
-function hExtractLine1(byref filename as string) as string
+function hExtractLine1(byref filename as const string) as string
 	var f = freefile()
 	if open(filename, for input, as #f) then
 		print "couldn't open file '" + filename + "'"
@@ -65,7 +65,7 @@ function hExtractLine1(byref filename as string) as string
 	function = line1
 end function
 
-function hShell(byref ln as string) as integer
+function hShell(byref ln as const string) as integer
 	var result = shell(ln)
 	select case result
 	case -1
@@ -79,7 +79,7 @@ function hShell(byref ln as string) as integer
 	return result
 end function
 
-sub hTest(byref hfile as string)
+sub hTest(byref hfile as const string)
 	var line1 = hExtractLine1(hfile)
 
 	'' @ignore?
@@ -133,7 +133,7 @@ end type
 
 dim shared as DIRQUEUE dirs
 
-private sub dirsAppend(byref path as string)
+private sub dirsAppend(byref path as const string)
 	dim as DIRNODE ptr node = callocate(sizeof(DIRNODE))
 	node->path = pathAddDiv(path)
 	if dirs.tail then
@@ -157,7 +157,7 @@ private sub dirsDropHead()
 	end if
 end sub
 
-private sub hScanParent(byref parent as string, byref filepattern as string)
+private sub hScanParent(byref parent as const string, byref filepattern as const string)
 	'' Scan for files
 	var found = dir(parent + filepattern, fbNormal)
 	while len(found) > 0
@@ -188,7 +188,7 @@ private sub hScanParent(byref parent as string, byref filepattern as string)
 	wend
 end sub
 
-sub hScanDirectory(byref rootdir as string, byref filepattern as string)
+sub hScanDirectory(byref rootdir as const string, byref filepattern as const string)
 	dirsAppend(rootdir)
 
 	'' Work off the queue -- each subdir scan can append new subdirs


### PR DESCRIPTION
Primarily is changes for compatibility when running on windows shells:

- add makefile option `ENABLE_STANDALONE=1` to build fbc with a different directory search order relative to the installed location of fbfrog
- add makefile option `ENABLE_COMMON_PATHDIV=1` to change the internal handling of path separator characters and command line arguments to normalize between forward and back slash separators - both are used on some windows shells
- update the test runner to build and pass when executed on windows - which requires normalization of path separators used in compared test results
- add `__FB_WIN32__` specific code in fbfrog to handle some kinds of command line arguments like single quoted arguments and escaped characters
- improve filename pattern matching in `-addinclude`, `-emit`, `-inclib`, `-title`, and `-undef` where a destination `.bi` file may be specified by joining on the path from the `-o directory` output option

Tested on ubuntu 16 - 32-bit
- all fbfrog tests passed 
- full execution of https://github.com/freebasic/fbbindings passed

Tested on win 10
- all fbfrog tests passed
- some parts of https://github.com/freebasic/fbbindings passed and other parts not tested because of other shell / host dependencies in fbbindings
